### PR TITLE
add C# solution CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
       - name: Compile each solution

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+      - name: Compile each solution
+        shell: bash
+        run: |
+          set -euo pipefail
+          work="$(mktemp -d)"
+          dotnet new console --framework net8.0 --output "$work" >/dev/null
+          while IFS= read -r -d '' file; do
+            cp "$file" "$work/Program.cs"
+            dotnet build "$work" --no-restore --nologo --verbosity quiet
+          done < <(find . -name '*.cs' -print0)
+

--- a/백트래킹/9663.cs
+++ b/백트래킹/9663.cs
@@ -12,7 +12,7 @@ namespace baekjoon
         static void Main(string[] args)
         {
             DFS(0);
-            Console.WriteLine(res);
+            Console.WriteLine(result);
             sr.Close();
         }
 


### PR DESCRIPTION
## Summary

- add a least-privilege CI workflow for the repository's actual toolchain
- install dependencies from the committed lockfile where one exists
- run the strongest repeatable build, test, lint, or syntax checks supported by the project
- include baseline repairs required for those checks when applicable

## Why

GitHub Actions was enabled, but this repository had no code-validation workflow. Changes could reach the default branch or deployment without an automated build gate.

## Validation

- workflow YAML parsed successfully
- whitespace validation passed
- project checks were run locally where the toolchain is available
- this PR's GitHub Actions run provides the clean hosted-runner verification
